### PR TITLE
fix(source): parse 2160p.uhd.remux as uhd.bluray

### DIFF
--- a/taginfo/taginfo.csv
+++ b/taginfo/taginfo.csv
@@ -710,7 +710,7 @@ source,TS,Telesync,telesync|ts,,movie,
 source,TVHSRiP,TV HS (rip),tvhs[\-\._ ]?rip,,,
 source,TVRiP,TV (rip),tv[\-\._ ]?rip,,,
 source,UHD.BDRiP,Ultra High-Definiton BluRay (rip),uhd[\-\._ ]?(?:bd)?rip,,movie,
-source,UHD.BluRay,Ultra High-Definiton BluRay,uhd[\-\._ ]?(?:blu[\-\._ ]?ray|bd),,movie,
+source,UHD.BluRay,Ultra High-Definiton BluRay,uhd[\-\._ ]?(?:blu[\-\._ ]?ray|bd|remux),,movie,
 source,UHDTV,Ultra High-Definition TV,,,,
 source,UMDMOVIE,Universal Media Disc Movie,,,,
 source,UMDRiP,Universal Media Disc (rip),umd[\-\._ ]?rip,,game,1

--- a/tests.yaml
+++ b/tests.yaml
@@ -1535,6 +1535,17 @@
   audio: "DD"
   language: "FRENCH"
   group: "XF"
+"Talk.to.Me.2022.2160p.UHD.Remux.HEVC.DoVi.TrueHD.Atmos.7.1-playBD":
+  type: "movie"
+  title: "Talk to Me"
+  source: "UHD.BluRay"
+  resolution: "2160p"
+  year: 2022
+  codec: "HEVC"
+  hdr: "DV"
+  audio: "TrueHD Atmos"
+  channels: "7.1"
+  group: "playBD"
 "30.Grader.I.Februari.S01E01.SWEDiSH.HDTV.XviD-HDR":
   type: "episode"
   title: "30 Grader I Februari"


### PR DESCRIPTION
Fixes the source parsing for releases that does not contain `Bluray` (they should) like releases from `playBD`. Cross checked against multiple indexers.

Looks like it does not recognize Remux either.

And their 1080p remuxes does lack source as well. Example: `Talk.to.Me.2022.1080p.Remux.AVC.TrueHD.Atmos.7.1-playBD`.

