### PR TITLE
fix(lexer): correctly parse four digit episode numbers

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -324,7 +324,7 @@ func NewIDLexer() Lexer {
 
 // NewEpisodeLexer creates a tag lexer for a single episode (`- 2 -`, `- 867 (`, `- 100 [`).
 func NewEpisodeLexer() Lexer {
-	re, lb := regexp.MustCompile(`^(\d{1,3})(\b|[\._ ]?[\-\[\]\(\)\{\}])`), regexp.MustCompile(`-[\-\._ ]{1,3}$`)
+	re, lb := regexp.MustCompile(`^(\d{1,4})(\b|[\._ ]?[\-\[\]\(\)\{\}])`), regexp.MustCompile(`-[\-\._ ]{1,3}$`)
 	return TagLexer{
 		Lex: func(src, buf []byte, start, end []Tag, i, n int) ([]Tag, []Tag, int, int, bool) {
 			// compare against src, and match "lookbehind"

--- a/tests.yaml
+++ b/tests.yaml
@@ -2162,6 +2162,14 @@
   day: 6
   codec: "HEVC x265"
   group: "MeGusta"
+"[SubsPlease] One Piece - 1125 (1080p) [7E631F90].mkv":
+  type: "episode"
+  title: "One Piece"
+  resolution: "1080p"
+  episode: 1125
+  site: "SubsPlease"
+  sum: "7E631F90"
+  ext: "mkv"
 "Party.Planner.with.David.Tutera.S01E46.Dr..Zhivago-A-Go-Go.720p":
   type: "episode"
   title: "Party Planner with David Tutera"


### PR DESCRIPTION
Currently four digit episode numbers result in the type being `movie` and the episode being `0`.
This fixes the issue by also allowing up to four digits in the regex of `NewEpisodeLexer`.